### PR TITLE
Add new endpoint to `RegisterWithRecords` on BaseRegistrar 

### DIFF
--- a/contracts/src/L2/RegistrarController.sol
+++ b/contracts/src/L2/RegistrarController.sol
@@ -183,31 +183,27 @@ contract RegistrarController is Ownable {
         price = (price >= discount.discount) ? price - discount.discount : 0;
     }
 
-    function registerETH(RegisterRequest calldata request, uint16 ownerControlledFuses)
-        public
-        payable
-        validRegistration(request)
-    {
+    function registerETH(RegisterRequest calldata request) public payable validRegistration(request) {
         uint256 price = registerPrice(request.name, request.duration);
 
         _validateETHPayment(price);
 
-        _register(request, ownerControlledFuses);
+        _register(request);
 
         _refundExcessEth(price);
     }
 
-    function discountedRegisterETH(
-        RegisterRequest calldata request,
-        uint16 ownerControlledFuses,
-        bytes32 discountKey,
-        bytes calldata validationData
-    ) public payable validateDiscount(discountKey, validationData) validRegistration(request) {
+    function discountedRegisterETH(RegisterRequest calldata request, bytes32 discountKey, bytes calldata validationData)
+        public
+        payable
+        validateDiscount(discountKey, validationData)
+        validRegistration(request)
+    {
         uint256 price = discountRentPrice(request.name, request.duration, discountKey);
 
         _validateETHPayment(price);
 
-        _register(request, ownerControlledFuses);
+        _register(request);
         discountedRegistrants[msg.sender] = true;
 
         _refundExcessEth(price);
@@ -236,13 +232,8 @@ contract RegistrarController is Ownable {
         emit ETHPaymentProcessed(msg.sender, price);
     }
 
-    function _register(RegisterRequest calldata request, uint16 ownerControlledFuses) internal {
-        uint256 expires = base.register(
-            uint256(keccak256(bytes(request.name))), 
-            request.owner, 
-            request.duration, 
-            request.resolver
-        );
+    function _register(RegisterRequest calldata request) internal {
+        uint256 expires = base.register(uint256(keccak256(bytes(request.name))), request.owner, request.duration);
 
         if (request.data.length > 0) {
             _setRecords(request.resolver, keccak256(bytes(request.name)), request.data);

--- a/contracts/test/BaseRegistrar/BaseRegistrarBase.t.sol
+++ b/contracts/test/BaseRegistrar/BaseRegistrarBase.t.sol
@@ -10,11 +10,14 @@ import {ETH_NODE, BASE_ETH_NODE} from "src/util/Constants.sol";
 contract BaseRegistrarBase is Test {
     Registry public registry;
     BaseRegistrar public baseRegistrar;
-    address public owner = makeAddr("0x1");
-    address public user = makeAddr("0x2");
-    address public controller = makeAddr("0x3");
+    address public owner = makeAddr("owner");
+    address public user = makeAddr("user");
+    address public controller = makeAddr("controller");
+    address public resolver = makeAddr("resolver");
+    uint64 public ttl = 0;
     bytes32 public label = keccak256("test");
     uint256 public id = uint256(label);
+    bytes32 public node = keccak256(abi.encodePacked(BASE_ETH_NODE, label));
     uint256 public duration = 365 days;
     uint256 public blockTimestamp = 1716496498; // May 23, 2024
 

--- a/contracts/test/BaseRegistrar/RegisterWithRecord.t.sol
+++ b/contracts/test/BaseRegistrar/RegisterWithRecord.t.sol
@@ -1,0 +1,91 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {BaseRegistrar} from "src/L2/BaseRegistrar.sol";
+import {BaseRegistrarBase} from "./BaseRegistrarBase.t.sol";
+import {ERC721} from "lib/solady/src/tokens/ERC721.sol";
+import {ENS} from "ens-contracts/registry/ENS.sol";
+import {BASE_ETH_NODE, GRACE_PERIOD} from "src/util/Constants.sol";
+
+contract RegisterWithRecord is BaseRegistrarBase {
+    function test_reverts_whenTheRegistrarIsNotLive() public {
+        vm.prank(address(baseRegistrar));
+        registry.setOwner(BASE_ETH_NODE, owner);
+        vm.expectRevert(BaseRegistrar.RegistrarNotLive.selector);
+        baseRegistrar.registerWithRecord(id, user, duration, resolver, ttl);
+    }
+
+    function test_reverts_whenCalledByNonController(address caller) public {
+        vm.prank(caller);
+        vm.expectRevert(BaseRegistrar.OnlyController.selector);
+        baseRegistrar.registerWithRecord(id, user, duration, resolver, ttl);
+    }
+
+    function test_successfullyRegisters() public {
+        _registrationSetup();
+
+        vm.expectEmit(address(baseRegistrar));
+        emit ERC721.Transfer(address(0), user, id);
+        vm.expectEmit(address(registry));
+        emit ENS.NewOwner(BASE_ETH_NODE, bytes32(id), user);
+        vm.expectEmit(address(baseRegistrar));
+        emit BaseRegistrar.NameRegisteredWithRecord(id, user, duration + blockTimestamp, resolver, ttl);
+
+        vm.warp(blockTimestamp);
+        vm.prank(controller);
+        uint256 expires = baseRegistrar.registerWithRecord(id, user, duration, resolver, ttl);
+
+        address ownerOfToken = baseRegistrar.ownerOf(id);
+        assertEq(ownerOfToken, user);
+        assertEq(baseRegistrar.nameExpires(id), expires);
+        assertEq(registry.resolver(node), resolver);
+        assertEq(registry.ttl(node), ttl);
+    }
+
+    function test_successfullyRegisters_afterExpiry(address newOwner) public {
+        vm.assume(newOwner != user && newOwner != address(0));
+        _registrationSetup();
+        _registerName(label, user, duration);
+
+        uint256 newBlockTimestamp = blockTimestamp + duration + GRACE_PERIOD + 1;
+        vm.expectEmit(address(baseRegistrar));
+        emit ERC721.Transfer(user, address(0), id); // on _burn(id)
+        vm.expectEmit(address(baseRegistrar));
+        emit ERC721.Transfer(address(0), newOwner, id);
+        vm.expectEmit(address(registry));
+        emit ENS.NewOwner(BASE_ETH_NODE, bytes32(id), newOwner);
+        vm.expectEmit(address(baseRegistrar));
+        emit BaseRegistrar.NameRegisteredWithRecord(id, newOwner, duration + newBlockTimestamp, resolver, ttl);
+
+        vm.warp(newBlockTimestamp);
+        vm.prank(controller);
+        uint256 expires = baseRegistrar.registerWithRecord(id, newOwner, duration, resolver, ttl);
+
+        address ownerOfToken = baseRegistrar.ownerOf(id);
+        assertEq(ownerOfToken, newOwner);
+        assertEq(baseRegistrar.nameExpires(id), expires);
+        assertEq(registry.resolver(node), resolver);
+        assertEq(registry.ttl(node), ttl);
+    }
+
+    function test_reverts_ifTheNameIsNotAvailable(address newOwner) public {
+        vm.assume(newOwner != user);
+        _registrationSetup();
+        _registerName(label, user, duration);
+
+        vm.expectRevert(abi.encodeWithSelector(BaseRegistrar.NotAvailable.selector, id));
+        vm.prank(controller);
+        baseRegistrar.registerWithRecord(id, user, duration, resolver, ttl);
+    }
+
+    function test_reverts_ifTheNameIsNotAvailable_duringGracePeriod(address newOwner) public {
+        vm.assume(newOwner != user);
+        _registrationSetup();
+        _registerName(label, user, duration);
+
+        vm.expectRevert(abi.encodeWithSelector(BaseRegistrar.NotAvailable.selector, id));
+        vm.warp(blockTimestamp + duration + GRACE_PERIOD - 1);
+        vm.prank(controller);
+        baseRegistrar.registerWithRecord(id, user, duration, resolver, ttl);
+    }
+}

--- a/contracts/test/RegistrarController/RegistrarControllerBase.t.sol
+++ b/contracts/test/RegistrarController/RegistrarControllerBase.t.sol
@@ -8,7 +8,6 @@ import {BaseRegistrar} from "src/L2/BaseRegistrar.sol";
 import {Registry} from "src/L2/Registry.sol";
 import {IReverseRegistrar} from "src/L2/interface/IReverseRegistrar.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {INameWrapper} from "ens-contracts/wrapper/INameWrapper.sol";
 import {ENS} from "ens-contracts/registry/ENS.sol";
 
 import {MockBaseRegistrar} from "test/mocks/MockBaseRegistrar.sol";
@@ -26,7 +25,6 @@ contract RegistrarControllerBase is Test {
     MockBaseRegistrar public base;
     MockReverseRegistrar public reverse;
     MockUSDC public usdc;
-    MockNameWrapper public wrapper;
     MockPriceOracle public prices;
     Registry public registry;
 
@@ -37,18 +35,16 @@ contract RegistrarControllerBase is Test {
         base = new MockBaseRegistrar();
         reverse = new MockReverseRegistrar();
         usdc = new MockUSDC();
-        wrapper = new MockNameWrapper();
         prices = new MockPriceOracle();
         registry = new Registry(owner);
         _establishNamespace();
-        
+
         vm.prank(owner);
         controller = new RegistrarController(
             BaseRegistrar(address(base)),
             IPriceOracle(address(prices)),
             IERC20(address(usdc)),
             IReverseRegistrar(address(reverse)),
-            INameWrapper(address(wrapper)),
             owner
         );
     }
@@ -56,7 +52,6 @@ contract RegistrarControllerBase is Test {
     function test_controller_constructor() public view {
         assertEq(address(controller.prices()), address(prices));
         assertEq(address(controller.reverseRegistrar()), address(reverse));
-        assertEq(address(controller.nameWrapper()), address(wrapper));
         assertEq(address(controller.usdc()), address(usdc));
         assertTrue(reverse.hasClaimed());
         assertEq(controller.owner(), owner);


### PR DESCRIPTION
This is needed to avoid a secondary transaction when registering a name via the Controller without the Name Wrapper. 