### PR TITLE
[audit]  #12 : Same address can use multiple discounts through reentrancy

### DIFF
--- a/src/L2/RegistrarController.sol
+++ b/src/L2/RegistrarController.sol
@@ -432,8 +432,8 @@ contract RegistrarController is Ownable {
 
         _validatePayment(price);
 
-        _register(request);
         discountedRegistrants[msg.sender] = true;
+        _register(request);
 
         _refundExcessEth(price);
 


### PR DESCRIPTION
Reorder transactions to prevent reentrancy attack. 

_From Spearbit:_ 

**Description**
The `discountRegistrants` mapping is used to keep track of which addresses have already used a discount and block them from registering with another or the same discount again.

The mapping is checked in the `validDiscount` modifier and updated after` _registration` function. The user can specify a custom resolver address in the request on which `multicallWithNodeCheck` is called in the `_registration` function. This can be used to reenter the contract and use the same or a different discount before the `discountRegistrants` updated.

Note that as the `validDiscounts` checks the discount eligbility against the `msg.sender` the specified resolver must be the address that is eligible for the discount. This could be the case for smart contract wallets that can provide the needed `multicallWithNodeCheck` function to perform this exploit.

**Recommendation**
Move the update to the `discountRegistrants` state variable before doing the call to the resolver. This could be just before the `_register` statement or even in the `validDiscount` modifier.