### PR TITLE
[audit] #13: Make vars immutable where relevant

### DIFF
--- a/src/L2/BaseRegistrar.sol
+++ b/src/L2/BaseRegistrar.sol
@@ -29,7 +29,7 @@ contract BaseRegistrar is ERC721, Ownable {
     mapping(uint256 id => uint256 expiry) public nameExpires;
 
     /// @notice The Registry contract.
-    ENS public registry;
+    ENS public immutable registry;
 
     /// @notice The namehash of the TLD this registrar owns (eg, base.eth).
     bytes32 public immutable baseNode;

--- a/src/L2/discounts/AttestationValidator.sol
+++ b/src/L2/discounts/AttestationValidator.sol
@@ -22,7 +22,7 @@ contract AttestationValidator is Ownable, AttestationAccessControl, IDiscountVal
     address signer;
 
     /// @dev The EAS schema id for Coinbase Verified Accounts.
-    bytes32 schemaID;
+    bytes32 immutable schemaID;
 
     /// @notice Attestation Validator constructor
     ///

--- a/src/L2/discounts/ERC1155DiscountValidator.sol
+++ b/src/L2/discounts/ERC1155DiscountValidator.sol
@@ -12,10 +12,10 @@ import {IDiscountValidator} from "src/L2/interface/IDiscountValidator.sol";
 /// @author Coinbase (https://github.com/base-org/usernames)
 contract ERC1155DiscountValidator is IDiscountValidator {
     /// @notice The ERC1155 token contract to validate against.
-    IERC1155 token;
+    IERC1155 immutable token;
 
     /// @notice The ERC1155 token ID of the relevant NFT.
-    uint256 tokenId;
+    uint256 immutable tokenId;
 
     /// @notice ERC1155 Discount Validator constructor.
     ///


### PR DESCRIPTION
_From Spearbit:_

**Description**
The variables in this context have only been set in the constructor and there is no other way to modify them.

**Recommendation**
It would be best to define them as immutable:

|contract|parameter|
| ------- | ---------- |
|AttestationValidator|schemaID|
|ERC1155DiscountValidator|token|
|ERC1155DiscountValidator|tokenId|
|BaseRegistrar|registry|