### PR TITLE
[audit] #3: Swap lines for gas savings on expired signatures

### DIFF
--- a/src/lib/SignatureVerifier.sol
+++ b/src/lib/SignatureVerifier.sol
@@ -28,8 +28,8 @@ library SignatureVerifier {
     /// @return result The `result` decoded from `response`.
     function verify(bytes calldata request, bytes calldata response) internal view returns (address, bytes memory) {
         (bytes memory result, uint64 expires, bytes memory sig) = abi.decode(response, (bytes, uint64, bytes));
-        address signer = ECDSA.recover(makeSignatureHash(address(this), expires, request, result), sig);
         if (expires < block.timestamp) revert SignatureExpired();
+        address signer = ECDSA.recover(makeSignatureHash(address(this), expires, request, result), sig);
         return (signer, result);
     }
 }


### PR DESCRIPTION
_From Spearbit:_

**Description**
In `SignatureVerifier.verify` revert early when the signature is expired.

**Recommendation**
Swap the lines in this context:

```solidity
if (expires < block.timestamp) revert SignatureExpired();
address signer = ECDSA.recover(makeSignatureHash(address(this), expires, request, result), sig);
```

`forge snapshot --diff` `.gas-review`:

```
test_returnsResultsWithValidSignature(string) (gas: -3 (-0.006%)) 
test_revertsWhenTheSignerIsInvalid(string) (gas: -3 (-0.006%)) 
test_constructor() (gas: -200 (-0.017%)) 
test_constructor() (gas: -200 (-0.017%)) 
test_constructor() (gas: -200 (-0.017%)) 
test_constructor() (gas: -200 (-0.017%)) 
test_constructor() (gas: -200 (-0.017%)) 
test_constructor() (gas: -200 (-0.017%)) 
test_constructor_setsTheRootNodeOwner() (gas: -27 (-0.211%)) 
test_revertsWhenTheSignatureIsExpired(string) (gas: -4029 (-8.703%)) 
test_constructor() (gas: -8061 (-29.447%)) 
test_constructor() (gas: 1149508 (4199.116%)) 
Overall gas change: 1136185 (4.911%)
```