### PR TITLE
[audit] #5: Cache `expires` to save gas

### DIFF
--- a/src/L2/BaseRegistrar.sol
+++ b/src/L2/BaseRegistrar.sol
@@ -260,11 +260,13 @@ contract BaseRegistrar is ERC721, Ownable {
     ///
     /// @return The new expiry date.
     function renew(uint256 id, uint256 duration) external live onlyController returns (uint256) {
-        if (nameExpires[id] + GRACE_PERIOD < block.timestamp) revert NotRegisteredOrInGrace(id);
+        uint256 expires = nameExpires[id];
+        if (expires + GRACE_PERIOD < block.timestamp) revert NotRegisteredOrInGrace(id);
 
-        nameExpires[id] += duration;
-        emit NameRenewed(id, nameExpires[id]);
-        return nameExpires[id];
+        expires += duration;
+        nameExpires[id] = expires;
+        emit NameRenewed(id, expires);
+        return expires;
     }
 
     /// @notice Reclaim ownership of a name in ENS, if you own it in the registrar.


### PR DESCRIPTION
_From Spearbit:_

**Description**
`nameExpires[id]` has been read multiple times from storage. To save gas it can be cached.

**Recommendation**
cache `nameExpires[id]` in a stack variable:

```solidity
function renew(uint256 id, uint256 duration) external live onlyController returns (uint256) {
    uint256 nameExpiry = nameExpires[id];
    if (nameExpiry + GRACE_PERIOD < block.timestamp) revert NotRegisteredOrInGrace(id);

    nameExpiry += duration;
    nameExpires[id] = nameExpiry;
    emit NameRenewed(id, nameExpiry);
    return nameExpiry;
}
```

`forge snapshot --diff` `.gas-review`:

```
test_reverts_whenNotInGracePeriod() (gas: -6 (-0.004%)) 
test_reverts_whenNotRegistered() (gas: -6 (-0.010%)) 
test_constructor_setsTheRootNodeOwner() (gas: -27 (-0.211%)) 
test_renewsOwnershipSuccessfully_whenInGracePeriod() (gas: -456 (-0.276%)) 
test_renewsOwnershipSuccessfully_whenNotExpired() (gas: -456 (-0.276%)) 
test_constructor() (gas: -8061 (-29.447%)) 
test_constructor() (gas: 1149708 (4199.847%)) 
Overall gas change: 1140696 (4.930%)
```