### PR TITLE
[audit] #8: `_isContract` optimization 

### DIFF
--- a/src/L2/ReverseRegistrar.sol
+++ b/src/L2/ReverseRegistrar.sol
@@ -183,7 +183,7 @@ contract ReverseRegistrar is Ownable {
     /// @return `true` if the address returned from `Ownable:owner()` == msg.sender, else `false`.
     function _ownsContract(address addr) internal view returns (bool) {
         // Determine if a contract exists at `addr` and return early if not
-        if (!_isContract(addr)) {
+        if (addr.code.length == 0) {
             return false;
         }
         // If a contract does exist, try and call `Ownable.owner()`
@@ -191,17 +191,6 @@ contract ReverseRegistrar is Ownable {
             return owner == msg.sender;
         } catch {
             return false;
-        }
-    }
-
-    /// @notice Check if the provided `addr` has a nonzero `extcodesize`.
-    ///
-    /// @param addr The address to check.
-    ///
-    /// @return result `true` if `extcodesize` >  0, else `false`.
-    function _isContract(address addr) internal view returns (bool result) {
-        assembly {
-            result := extcodesize(addr)
         }
     }
 }


### PR DESCRIPTION
This PR removes the assembly method `_isContract` and instead just uses `address.code.legnth`. The ~40 gas saved by the assembly does not justify the readability hit. 

_From Spearbit:_
**Description**
One can avoid extra operations by using a named return variable.

**Recommendation**
Use a named return variable and let the compiler solc take care of the conversion to bool:

```solidity
function _isContract(address addr) internal view returns (bool result) {
    assembly {
        result := extcodesize(addr)
    }
}
```