### PR TITLE
[audit] #9: Clarify comment on renewal pricing

### DIFF
--- a/src/L2/RegistrarController.sol
+++ b/src/L2/RegistrarController.sol
@@ -443,8 +443,9 @@ contract RegistrarController is Ownable {
     /// @notice Allows a caller to renew a name for a specified duration.
     ///
     /// @dev This `payable` method must receive appropriate `msg.value` to pass `_validatePayment()`.
-    ///     The price for renewal never incorporates pricing `premium`. Use the `base` price returned by the `rentPrice`
-    ///     tuple to determine the price for calling this method.
+    ///     The price for renewal never incorporates pricing `premium`. This is because we only expect
+    ///     renewal on names that are not expired or are in the grace period. Use the `base` price returned
+    ///     by the `rentPrice` tuple to determine the price for calling this method.
     ///
     /// @param name The name that is being renewed.
     /// @param duration The duration to extend the expiry, in seconds.


### PR DESCRIPTION
_From Spearbit:_

**Description**
This assumes that the `premium` is 0 which relies on two facts:

1. Currently you can only renew a token on BaseRegistrar before the grace period ends
2. The current implementation of the IPriceOracle uses the elapsed time after the grace period ends and thus it returns 0 for premium before that.

**Recommendation**
The above should be documented more in the NatSpec. Currently it is only mentioned that:
```solidity
    ///     The price for renewal never incorporates pricing `premium`. Use the `base` price returned by the `rentPrice`
    ///     tuple to determine the price for calling this method.
```