### PR TITLE
[audit] #14: Add clarifying comment to ERC1155DiscountValidator

### DIFF
--- a/src/L2/discounts/ERC1155DiscountValidator.sol
+++ b/src/L2/discounts/ERC1155DiscountValidator.sol
@@ -8,6 +8,7 @@ import {IDiscountValidator} from "src/L2/interface/IDiscountValidator.sol";
 /// @title Discount Validator for: ERC1155 NFTs
 ///
 /// @notice Implements an NFT ownership validator for a stored `tokenId` for an ERC1155 `token` contract.
+///         This discount validator should only be used for "soul-bound" tokens.
 ///
 /// @author Coinbase (https://github.com/base-org/usernames)
 contract ERC1155DiscountValidator is IDiscountValidator {


### PR DESCRIPTION
_From Spearbit:_

**Description**
The protocol intends to allow a name buyer to claim discount only once. However when the discount is decided by `ERC1155DiscountValidator`, a token holder can rotate his wallets by transferring the token to different accounts and hence can claim discount multiple times.

**Recommendation**
It should be made sure that the `ERC1155` token is a non-transferable token.