### PR TITLE
[audit] #1: Add gas optimization to Sha3 

### DIFF
--- a/src/lib/Sha3.sol
+++ b/src/lib/Sha3.sol
@@ -9,16 +9,14 @@ pragma solidity ^0.8.23;
 ///
 /// @author ENS (https://github.com/ensdomains/ens-contracts)
 library Sha3 {
-    // Hex encoding of "0123456789abcdef"
+    /// @notice Hex encoding of "0123456789abcdef"
     bytes32 constant ALPHABET = 0x30_31_32_33_34_35_36_37_38_39_61_62_63_64_65_66_00000000000000000000000000000000;
 
-    /**
-     * @dev An optimised function to compute the sha3 of the lower-case
-     *      hexadecimal representation of an Ethereum address.
-     * @param addr The address to hash
-     * @return ret The SHA3 hash of the lower-case hexadecimal encoding of the
-     *         input address.
-     */
+    /// @notice Calculates the hash of a lower-case Ethereum address
+    ///
+    /// @param addr The address to hash
+    ///
+    /// @return ret The SHA3 hash of the lower-case hexadecimal encoding of the input address.
     function hexAddress(address addr) internal pure returns (bytes32 ret) {
         assembly {
             for { let i := 40 } i {} {


### PR DESCRIPTION
_From Spearbit:_

**Description**
`hexAddress` can be optimised by replacing:

```solidity
div(addr, 0x10)
```
 with 
```solidity
shr(4, addr)
```
and
```solidity
gt(i, 0)
``` 
with 
```solidity
I
```

Also underscores can be added to `ALPHABET` to make it more readable.

[!Note] The current implementation copies the same implementation from [ens-contracts](https://github.com/ensdomains/ens-contracts/tree/545a0104d0fbdd10865743e25729a921a76fd950/contracts/reverseRegistrar/ReverseRegistrar.sol#L164-L181)

**Recommendation**
Apply the following patch to save around 40 gas:
```
diff --git a/src/lib/Sha3.sol b/src/lib/Sha3.sol
index 12cec00..5877a36 100644
--- a/src/lib/Sha3.sol
+++ b/src/lib/Sha3.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 library Sha3 {
     // Hex encoding of "0123456789abcdef"
-    bytes32 constant ALPHABET = 0x3031323334353637383961626364656600000000000000000000000000000000;
+    bytes32 constant ALPHABET = 0x30_31_32_33_34_35_36_37_38_39_61_62_63_64_65_66_00000000000000000000000000000000;
 
     /**
      * @dev An optimised function to compute the sha3 of the lower-case
@@ -14,13 +14,13 @@ library Sha3 {
      */
     function hexAddress(address addr) internal pure returns (bytes32 ret) {
         assembly {
-            for { let i := 40 } gt(i, 0) {} {
+            for { let i := 40 } i {} {
                 i := sub(i, 1)
                 mstore8(i, byte(and(addr, 0xf), ALPHABET))
-                addr := div(addr, 0x10)
+                addr := shr(4, addr)
                 i := sub(i, 1)
                 mstore8(i, byte(and(addr, 0xf), ALPHABET))
-                addr := div(addr, 0x10)
+                addr := shr(4, addr)
             }
 
             ret := keccak256(0, 40)
```