### PR TITLE
[audit] #7: Improved values and fixed units for ExponentialPremiumPrice testing

### DIFF
--- a/test/ExponentialPremiumPriceOracle/ExponentialPremiumOracleBase.t.sol
+++ b/test/ExponentialPremiumPriceOracle/ExponentialPremiumOracleBase.t.sol
@@ -16,7 +16,7 @@ contract ExponentialPremiumOracleBase is Test {
     uint256 rent10;
 
     uint256 startPremium = 1e18;
-    uint256 totalDays = 365 days;
+    uint256 totalDays = 21;
 
     function setUp() public {
         uint256[] memory rentPrices = new uint256[](6);


### PR DESCRIPTION
_From Spearbit_

**Description**
Note that how endValue calculated in the ExponentialPremiumPriceOracle.constructor:
`endValue = startPremium >> totalDays;`
`totalDays` is supposed to half `startPremium` for every day in includes and thus its unit needs to be in days and not seconds.

**Recommendation**
Use a smaller realistic value for `totalDays` and remove the `days` time unit