### PR TITLE
[audit] #4: Use FixedPointMathLib.mulWad in EDA.currentPrice

### DIFF
--- a/src/lib/EDAPrice.sol
+++ b/src/lib/EDAPrice.sol
@@ -29,8 +29,8 @@ library EDAPrice {
         uint256 percentWadRemainingPerPeriod = FixedPointMathLib.WAD - perPeriodDecayPercentWad;
 
         // percentWadRemainingPerPeriod can be safely cast because < 1e18
-        // ratio can be safely cast because will not overflow unless ratio > int256.max,
-        // which would require secondsElapsed > type(uint256).max, i.e. > 1.157e59 years
+        // ratio can be safely cast because will not overflow unless ratio > type(int256).max,
+        // which would require secondsElapsed > type(int256).max, i.e. > 5.78e76 or 1.8e69 years
 
         int256 multiplier = FixedPointMathLib.powWad(int256(percentWadRemainingPerPeriod), int256(ratio));
         uint256 price = FixedPointMathLib.mulWad(startPrice, uint256(multiplier));


### PR DESCRIPTION
_From Spearbit_

**Description**

In this context we have:
`uint256 price = (startPrice * uint256(multiplier)) / FixedPointMathLib.WAD;`
But one can use the already imported `FixedPointMathLib` from `solday`

**Recommendation**
The context can be replaced by the more optimised version from solady library:
`uint256 price = FixedPointMathLib.mulWad(startPrice, uint256(multiplier));`


