### PR TITLE
Add ERC721 discount validator

### DIFF
--- a/src/L2/discounts/ERC721DiscountValidator.sol
+++ b/src/L2/discounts/ERC721DiscountValidator.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import {IDiscountValidator} from "src/L2/interface/IDiscountValidator.sol";
+
+/// @title Discount Validator for: ERC721 NFTs
+///
+/// @notice Implements an NFT ownership validator for a ERC721 `token` contract.
+///         This discount validator should only be used for "soul-bound" tokens.
+///
+/// @author Coinbase (https://github.com/base-org/usernames)
+contract ERC721DiscountValidator is IDiscountValidator {
+    /// @notice The ERC721 token contract to validate against.
+    IERC721 immutable token;
+
+    /// @notice ERC721 Discount Validator constructor.
+    ///
+    /// @param tokenAddress The address of the token contract.
+    constructor(address tokenAddress) {
+        token = IERC721(tokenAddress);
+    }
+
+    /// @notice Required implementation for compatibility with IDiscountValidator.
+    ///
+    /// @dev No additional data is necessary to complete this validation. This validator checks that `claimer` has a nonzero
+    ///     `balanceOf` the stored `token` ERC721 contract.
+    ///
+    /// @param claimer the discount claimer's address.
+    ///
+    /// @return `true` if the validation data provided is determined to be valid for the specified claimer, else `false`.
+    function isValidDiscountRegistration(address claimer, bytes calldata) external view returns (bool) {
+        return (token.balanceOf(claimer) > 0);
+    }
+}

--- a/test/discounts/ERC721DiscountValidator/ERC721DiscountValidatorBase.t.sol
+++ b/test/discounts/ERC721DiscountValidator/ERC721DiscountValidatorBase.t.sol
@@ -1,0 +1,18 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC721DiscountValidator} from "src/L2/discounts/ERC721DiscountValidator.sol";
+import {MockERC721} from "test/mocks/MockERC721.sol";
+
+contract ERC721DiscountValidatorBase is Test {
+    ERC721DiscountValidator validator;
+    MockERC721 token;
+    address userA = makeAddr("userA");
+    address userB = makeAddr("userB");
+
+    function setUp() public {
+        token = new MockERC721();
+        validator = new ERC721DiscountValidator(address(token));
+    }
+}

--- a/test/discounts/ERC721DiscountValidator/IsValidDiscountRegistration.t.sol
+++ b/test/discounts/ERC721DiscountValidator/IsValidDiscountRegistration.t.sol
@@ -1,0 +1,20 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ERC721DiscountValidatorBase} from "./ERC721DiscountValidatorBase.t.sol";
+
+contract IsValidDiscountRegistration is ERC721DiscountValidatorBase {
+    function test_returnsFalse_whenTheClaimerDoesNotHaveTheToken() public view {
+        assertFalse(validator.isValidDiscountRegistration(userA, ""));
+    }
+
+    function test_returnsFalse_whenAnotherUserHasTheToken() public {
+        token.mint(userA, 1);
+        assertFalse(validator.isValidDiscountRegistration(userB, ""));
+    }
+
+    function test_returnsTrue_whenTheUserHasTheToken() public {
+        token.mint(userA, 1);
+        assertTrue(validator.isValidDiscountRegistration(userA, ""));
+    }
+}

--- a/test/mocks/MockERC721.sol
+++ b/test/mocks/MockERC721.sol
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract MockERC721 is ERC721 {
+    constructor() ERC721("", "") {}
+
+    function mint(address to, uint256 id) public {
+        _mint(to, id);
+    }
+}


### PR DESCRIPTION
This generic discount validator allows us to offer discounts to an arbitrary soul-bound ERC721 token. We don't explicitly check tokenIds; just the presence of a nonzero balance for the stored token address. 