### PR TITLE
[audit2] #1 Remove unused event

### DIFF
--- a/src/L2/EARegistrarController.sol
+++ b/src/L2/EARegistrarController.sol
@@ -176,13 +176,6 @@ contract EARegistrarController is Ownable {
     /// @param expires The date that the registration expires.
     event NameRegistered(string name, bytes32 indexed label, address indexed owner, uint256 expires);
 
-    /// @notice Emitted when a name is renewed.
-    ///
-    /// @param name The name that was renewed.
-    /// @param label The hashed label of the name.
-    /// @param expires The date that the renewed name expires.
-    event NameRenewed(string name, bytes32 indexed label, uint256 expires);
-
     /// @notice Emitted when the payment receiver is updated.
     ///
     /// @param newPaymentReceiver The address of the new payment receiver.


### PR DESCRIPTION
From spearbit:

Unnecessary NameRenewed event in EARegistrarController
Status: New
Severity: Informational

[created on Jul 19, 2024 at 02:55](https://cantina.xyz/code/c1b90106-1ce6-4905-9c00-97ae2e37277c/findings/1#comment-196edb7a-8875-48f9-bddd-1d25a4e7d0f2)
Description
The NameRenewed event is not necessary for the EARegistrarController as this controller cannot renew.

Recommendation
Consider removing this event.