### PR TITLE
[audit2] #8 Change resolver for reverse node when changing default resolver

### DIFF
--- a/src/L2/ReverseRegistrar.sol
+++ b/src/L2/ReverseRegistrar.sol
@@ -115,6 +115,7 @@ contract ReverseRegistrar is Ownable {
     function setDefaultResolver(address resolver) public onlyOwner {
         if (address(resolver) == address(0)) revert NoZeroAddress();
         defaultResolver = NameResolver(resolver);
+        registry.setResolver(BASE_REVERSE_NODE, resolver);
         emit DefaultResolverChanged(defaultResolver);
     }
 


### PR DESCRIPTION
This impl. expects #74 

From spearbit: 

Wildcard resolver not set when changing the default resolver on the reverse registrar.
Status: New
Severity: Informational
[rustyrabbit](https://cantina.xyz/u/rustyrabbit)
rustyrabbit

[created on Jul 22, 2024 at 04:12](https://cantina.xyz/code/c1b90106-1ce6-4905-9c00-97ae2e37277c/findings/8#comment-066b8de9-d365-4b35-ac11-37d5c81bd7d5)
Description
When setting or changing the default resolver the resolver of the [coinTypeAsHex].reverse and addr.reverse nodes are not actually set, only the default resolver used by the claim and setName functions is changed. [ENSIP-19](https://docs.ens.domains/ensip/19#deployment-and-discovery-of-evm-reverse-registrars) specifies wildcard resolution should be supported.

The Offchain resolver will also support wildcard of all the address subdomains with the format [address].[coinTypeAsHex].reverse. Although this is primarily meant for the resolver on L1 it is recommended to also set this on L2.

Recommendation
Set the resolver for the [coinTypeAsHex].reverse and addr.reverse nodes in the setDefaultResolver so the wildcard resolver for reverse registrar follows the latest version of the default resolver.