### PR TITLE
[audit2] #10 Add IExtendedResolver supported signal for L2Resolver

### DIFF
--- a/src/L2/L2Resolver.sol
+++ b/src/L2/L2Resolver.sol
@@ -7,6 +7,7 @@ import {ContentHashResolver} from "ens-contracts/resolvers/profiles/ContentHashR
 import {DNSResolver} from "ens-contracts/resolvers/profiles/DNSResolver.sol";
 import {ENS} from "ens-contracts/registry/ENS.sol";
 import {ExtendedResolver} from "ens-contracts/resolvers/profiles/ExtendedResolver.sol";
+import {IExtendedResolver} from "ens-contracts/resolvers/profiles/IExtendedResolver.sol";
 import {InterfaceResolver} from "ens-contracts/resolvers/profiles/InterfaceResolver.sol";
 import {Multicallable} from "ens-contracts/resolvers/Multicallable.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
@@ -218,6 +219,6 @@ contract L2Resolver is
         )
         returns (bool)
     {
-        return super.supportsInterface(interfaceID);
+        return (interfaceID == type(IExtendedResolver).interfaceId || super.supportsInterface(interfaceID));
     }
 }

--- a/test/L2Resolver/SupportsInterface.t.sol
+++ b/test/L2Resolver/SupportsInterface.t.sol
@@ -13,6 +13,7 @@ import {IMulticallable} from "ens-contracts/resolvers/IMulticallable.sol";
 import {INameResolver} from "ens-contracts/resolvers/profiles/INameResolver.sol";
 import {IPubkeyResolver} from "ens-contracts/resolvers/profiles/IPubkeyResolver.sol";
 import {ITextResolver} from "ens-contracts/resolvers/profiles/ITextResolver.sol";
+import {IExtendedResolver} from "ens-contracts/resolvers/profiles/IExtendedResolver.sol";
 
 contract SupportsInterface is L2ResolverBase {
     function test_supportsABIResolver() public view {
@@ -53,5 +54,9 @@ contract SupportsInterface is L2ResolverBase {
 
     function test_supportsTextResolver() public view {
         assertTrue(resolver.supportsInterface(type(ITextResolver).interfaceId));
+    }
+
+    function test_supportsExtendedResolver() public view {
+        assertTrue(resolver.supportsInterface(type(IExtendedResolver).interfaceId));
     }
 }


### PR DESCRIPTION
From spearbit: 

L2Resolver does not indicate support for wildcard resolution 
Status: New
Severity: Informational
[rustyrabbit](https://cantina.xyz/u/rustyrabbit)
rustyrabbit

[created on Jul 22, 2024 at 05:06](https://cantina.xyz/code/c1b90106-1ce6-4905-9c00-97ae2e37277c/findings/10#comment-4a76d00e-40b0-410c-953c-bc1bfebd9620)
Description
The L2Resolver does not include the interface for the extended resolver (resolve()) in the supportsInterface() function. Although ENSIP-19 specifies the resolver should always be called via the CCIP-read gateway clients can have their own use cases where this call is instantiated from the client for other purposes than ENSIP-19.

Recommendation
Add the extender resolver interface to the supported interfaces. Note that this isn't done in the ExtendedResolver from the ENS library itself.