### PR TITLE
[audit2] #12 Remove reverse claiming from EARegistrarController

### DIFF
--- a/src/L2/EARegistrarController.sol
+++ b/src/L2/EARegistrarController.sol
@@ -257,8 +257,6 @@ contract EARegistrarController is Ownable {
 
     /// @notice Registrar Controller construction sets all of the requisite external contracts.
     ///
-    /// @dev Assigns ownership of this contract's reverse record to the `owner_`.
-    ///
     /// @param base_ The base registrar contract.
     /// @param prices_ The pricing oracle contract.
     /// @param reverseRegistrar_ The reverse registrar contract.
@@ -281,7 +279,6 @@ contract EARegistrarController is Ownable {
         rootName = rootName_;
         paymentReceiver = paymentReceiver_;
         _initializeOwner(owner_);
-        reverseRegistrar.claim(owner_);
     }
 
     /// @notice Allows the `owner` to set discount details for a specified `key`.

--- a/test/EARegistrarController/EARegistrarControllerBase.t.sol
+++ b/test/EARegistrarController/EARegistrarControllerBase.t.sol
@@ -66,7 +66,6 @@ contract EARegistrarControllerBase is Test {
     function test_controller_constructor() public view {
         assertEq(address(controller.prices()), address(prices));
         assertEq(address(controller.reverseRegistrar()), address(reverse));
-        assertTrue(reverse.hasClaimed(owner));
         assertEq(controller.owner(), owner);
         assertEq(controller.rootNode(), rootNode);
         assertEq(keccak256(bytes(controller.rootName())), keccak256(bytes(rootName)));


### PR DESCRIPTION
Since the EA Registrar Controller will be a short-lived contract, opt out of claiming the reverse node. 

From spearbit: 
Null value is set as the resolver of reverse records for EARegistrarController 
Status: New
Severity: Informational
[AkshaySrivastav](https://cantina.xyz/u/AkshaySrivastav)
AkshaySrivastav

[created on Jul 22, 2024 at 06:17](https://cantina.xyz/code/c1b90106-1ce6-4905-9c00-97ae2e37277c/findings/12#comment-817ae415-2412-4f18-83ad-8786a48a5b5f)
Description
The constructor of EARegistrarController performs the IReverseRegistrar.claim call to claim its reverse records.

By analysing the deployment sequence of protocol contracts and the provided [integration tests](https://cantina.xyz/code/c1b90106-1ce6-4905-9c00-97ae2e37277c/test/IntegrationTest.t.sol#L77-L96) it can be seen that during the deployment of EARegistrarController the ReverseRegistrar::defaultResolver state variable is address(0) (as the default L2Resolver is not deployed yet). Hence the resolver of reverse records for EARegistrarController is set to address(0).

Assuming that the RegistrarController will be deployed after early registration period, this issue should not impact RegistrarController.

Recommendation
Make sure the owner of EARegistrarController manually sets the resolver of reverse records for EARegistrarController after protocol deployment.