### PR TITLE
[audit2] #11 Add reverse node claim to L2 Resolver

### DIFF
--- a/src/L2/L2Resolver.sol
+++ b/src/L2/L2Resolver.sol
@@ -14,6 +14,8 @@ import {NameResolver} from "ens-contracts/resolvers/profiles/NameResolver.sol";
 import {PubkeyResolver} from "ens-contracts/resolvers/profiles/PubkeyResolver.sol";
 import {TextResolver} from "ens-contracts/resolvers/profiles/TextResolver.sol";
 
+import {IReverseRegistrar} from "src/L2/interface/IReverseRegistrar.sol";
+
 /// @title L2 Resolver
 ///
 /// @notice The default resolver for the Base Usernames project. This contract implements the functionality of the ENS
@@ -112,6 +114,7 @@ contract L2Resolver is
         registrarController = registrarController_;
         reverseRegistrar = reverseRegistrar_;
         _initializeOwner(owner_);
+        IReverseRegistrar(reverseRegistrar_).claim(owner_);
     }
 
     /// @notice Allows the `owner` to set the registrar controller contract address.

--- a/test/L2Resolver/L2ResolverBase.t.sol
+++ b/test/L2Resolver/L2ResolverBase.t.sol
@@ -7,11 +7,12 @@ import {Registry} from "src/L2/Registry.sol";
 import {ENS} from "ens-contracts/registry/ENS.sol";
 import {ETH_NODE, REVERSE_NODE} from "src/util/Constants.sol";
 import {NameEncoder} from "ens-contracts/utils/NameEncoder.sol";
+import {MockReverseRegistrar} from "test/mocks/MockReverseRegistrar.sol";
 
 contract L2ResolverBase is Test {
     L2Resolver public resolver;
     Registry public registry;
-    address reverse = makeAddr("reverse");
+    address reverse;
     address controller = makeAddr("controller");
     address owner = makeAddr("owner");
     address user = makeAddr("user");
@@ -21,6 +22,7 @@ contract L2ResolverBase is Test {
 
     function setUp() public {
         registry = new Registry(owner);
+        reverse = address(new MockReverseRegistrar());
         resolver = new L2Resolver(ENS(address(registry)), controller, reverse, owner);
         (, node) = NameEncoder.dnsEncodeName(name);
         _establishNamespace();


### PR DESCRIPTION
From spearbit: 

Missing explicitly claiming the reverse resolution record for L2Resolver 
Status: New
Severity: Informational
[AkshaySrivastav](https://cantina.xyz/u/AkshaySrivastav)
AkshaySrivastav

[created on Jul 22, 2024 at 05:52](https://cantina.xyz/code/c1b90106-1ce6-4905-9c00-97ae2e37277c/findings/11#comment-4142220d-aa78-41dd-9bc9-37fd449b81f9)
Description
The current implementation of L2Resolver contract does not claim the reverse resolution record for itself explicitly.

Ideally just like [RegistrarController](https://cantina.xyz/code/c1b90106-1ce6-4905-9c00-97ae2e37277c/src/L2/RegistrarController.sol#L287), [EARegistrarController](https://cantina.xyz/code/c1b90106-1ce6-4905-9c00-97ae2e37277c/src/L2/EARegistrarController.sol#L284) & ENS's [PublicResolver](https://github.com/ensdomains/ens-contracts/blob/staging/contracts/resolvers/PublicResolver.sol#L75) reverse record should be explicitly claimed for L2Resolver during its construction.

Recommendation
Add the IReverseRegistrar.claim call in L2Resolver::constructor:
```solidity
    constructor(ENS ens_, address registrarController_, address reverseRegistrar_, address owner_) {
        ens = ens_;
        registrarController = registrarController_;
        reverseRegistrar = reverseRegistrar_;
        _initializeOwner(owner_);
+       IReverseRegistrar(reverseRegistrar).claim(owner_);
    }
```