### PR TITLE
Add configurable reverse node to ReverseRegistrar

### DIFF
--- a/script/deploy/DeployReverseRegistrar.s.sol
+++ b/script/deploy/DeployReverseRegistrar.s.sol
@@ -18,14 +18,15 @@ contract DeployReverseRegistrar is Script {
 
         ReverseRegistrar revRegstrar = new ReverseRegistrar(
             Registry(ensAddress),
-            deployerAddress // deployer as owner
+            deployerAddress, // deployer as owner
+            BASE_REVERSE_NODE
         );
 
         // establish the reverse registrar as the owner of the 'addr.reverse' node
         bytes32 reverseLabel = keccak256("reverse");
-        bytes32 addrLabel = keccak256("addr");
+        bytes32 baseReverseLabel = keccak256("80002105");
         registry.setSubnodeOwner(0x0, reverseLabel, deployerAddress);
-        registry.setSubnodeOwner(REVERSE_NODE, addrLabel, address(revRegstrar));
+        registry.setSubnodeOwner(REVERSE_NODE, baseReverseLabel, address(revRegstrar));
 
         console.log(address(revRegstrar));
 

--- a/test/IntegrationTest.t.sol
+++ b/test/IntegrationTest.t.sol
@@ -22,7 +22,7 @@ import {
     ETH_NODE,
     BASE_ETH_NODE,
     REVERSE_NODE,
-    ADDR_REVERSE_NODE,
+    BASE_REVERSE_NODE,
     GRACE_PERIOD,
     BASE_ETH_NAME
 } from "src/util/Constants.sol";
@@ -59,7 +59,7 @@ contract IntegrationTest is Test {
         payments = makeAddr("payments");
 
         registry = new Registry(owner);
-        reverseRegistrar = new ReverseRegistrar(registry, owner);
+        reverseRegistrar = new ReverseRegistrar(registry, owner, BASE_REVERSE_NODE);
 
         uint256[] memory rentPrices = new uint256[](6);
         rentPrices[0] = 317_097_919_837;
@@ -107,10 +107,8 @@ contract IntegrationTest is Test {
         registry.setSubnodeOwner(ROOT_NODE, ETH_LABEL, owner);
         registry.setSubnodeOwner(ETH_NODE, BASE_LABEL, address(baseRegistrar));
 
-        // establish addr.reverse namespace and assign ownership of addr.reverse to the reverse registrar
-        registry.setSubnodeOwner(ROOT_NODE, REVERSE_LABEL, owner);
-        registry.setSubnodeOwner(REVERSE_NODE, ADDR_LABEL, address(reverseRegistrar));
         // establish 80002105.reverse namespace and assign ownership to the reverse registrar
+        registry.setSubnodeOwner(ROOT_NODE, REVERSE_LABEL, owner);
         registry.setSubnodeOwner(REVERSE_NODE, keccak256("80002105"), address(reverseRegistrar));
         vm.stopPrank();
     }

--- a/test/ReverseRegistrar/ReverseRegistrarBase.t.sol
+++ b/test/ReverseRegistrar/ReverseRegistrarBase.t.sol
@@ -5,7 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {ReverseRegistrar} from "src/L2/ReverseRegistrar.sol";
 import {Registry} from "src/L2/Registry.sol";
 import {ENS} from "ens-contracts/registry/ENS.sol";
-import {ETH_NODE, REVERSE_NODE} from "src/util/Constants.sol";
+import {ETH_NODE, REVERSE_NODE, BASE_REVERSE_NODE} from "src/util/Constants.sol";
 
 contract ReverseRegistrarBase is Test {
     address public owner = makeAddr("owner");
@@ -17,7 +17,7 @@ contract ReverseRegistrarBase is Test {
 
     function setUp() public {
         registry = new Registry(owner);
-        reverse = new ReverseRegistrar(ENS(address(registry)), owner);
+        reverse = new ReverseRegistrar(ENS(address(registry)), owner, BASE_REVERSE_NODE);
         vm.prank(owner);
         reverse.setControllerApproval(controller, true);
         _registrySetup();


### PR DESCRIPTION
Add support for setting the `reverseNode` upon construction on ReverseRegistrar. This will support deploying the ReverseRegistrar to networks other than Base mainnet while maintaining compliance with ENSIP-19. 