### PR TITLE
Change constant for minimum duration

### DIFF
--- a/src/L2/RegistrarController.sol
+++ b/src/L2/RegistrarController.sol
@@ -97,7 +97,7 @@ contract RegistrarController is Ownable {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @notice The minimum registration duration, specified in seconds.
-    uint256 public constant MIN_REGISTRATION_DURATION = 28 days;
+    uint256 public constant MIN_REGISTRATION_DURATION = 365 days;
 
     /// @notice The minimum name length.
     uint256 public constant MIN_NAME_LENGTH = 3;

--- a/test/Integration/IntegrationTestBase.t.sol
+++ b/test/Integration/IntegrationTestBase.t.sol
@@ -123,7 +123,7 @@ contract IntegrationTestBase is Test {
         vm.startPrank(alice);
 
         string memory name = "alice";
-        uint256 duration = 90 days;
+        uint256 duration = 365.25 days;
 
         uint256 registerPrice = registrarController.registerPrice(name, duration);
         vm.deal(alice, registerPrice);


### PR DESCRIPTION
From: 
```solidity
    /// @notice The minimum registration duration, specified in seconds.
    uint256 public constant MIN_REGISTRATION_DURATION = 28 days;
``` 

To: 
```solidity
    /// @notice The minimum registration duration, specified in seconds.
    uint256 public constant MIN_REGISTRATION_DURATION = 365 days;
```