### PR TITLE
Add `deploy` profile to foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -17,7 +17,7 @@ remappings = [
 fs_permissions = [{access = "read", path = "./script/premint/"}]
 auto_detect_remappings = false
 
-[profile.deploy]
+[profile.production]
 src = "src"
 out = "out"
 libs = ["lib"]


### PR DESCRIPTION
Adds an explicit profile for deployment builds. Employ optimizers for more efficient bytecode, pin settings that can affect build output for reproducibility.

`via_ir = true` // Route compilation through the Yul IR (intermediate rep) pipeine, generally get smaller bytecode, better optimization, lower gas at runtime
`optimizer = true` // use the compiler optimizer
`optimizer_runs = 10000` // higher runs optimizes for better runtime gas at the expense of possibly more expensive one-time deployment costs, definitely a desirable choice to absorb onetime higher gas during deployment for lower per-call gas to users
`evm_version = "cancun"` // latest evm version compatible with solidity 0.8.26
`bytecode_hash = "ipfs"` // already the foundry default but doesn't hurt to pin this explicitly. has something to do with 
`offline = true` // no fresh network fetches for dependencies - we want these fixed where we have them, and this expects that we already have all necessary dependencies installed at the correct commit locally when building