### PR TITLE
style: apply forge fmt formatting to Solidity files

### DIFF
--- a/src/L2/ReverseRegistrar.sol
+++ b/src/L2/ReverseRegistrar.sol
@@ -147,11 +147,7 @@ contract ReverseRegistrar is Ownable {
     /// @param resolver The address of the resolver to set.
     ///
     /// @return The ENS node hash of the base-specific reverse record.
-    function claimForBaseAddr(address addr, address owner, address resolver)
-        public
-        authorized(addr)
-        returns (bytes32)
-    {
+    function claimForBaseAddr(address addr, address owner, address resolver) public authorized(addr) returns (bytes32) {
         bytes32 labelHash = Sha3.hexAddress(addr);
         bytes32 baseReverseNode = keccak256(abi.encodePacked(reverseNode, labelHash));
         emit BaseReverseClaimed(addr, baseReverseNode);

--- a/src/L2/ReverseRegistrarV2.sol
+++ b/src/L2/ReverseRegistrarV2.sol
@@ -134,9 +134,8 @@ contract ReverseRegistrarV2 is Ownable {
         uint256[] memory cointypes,
         bytes memory signature
     ) external returns (bytes32) {
-        IL2ReverseRegistrar(l2ReverseRegistrar).setNameForAddrWithSignature(
-            addr, signatureExpiry, name, cointypes, signature
-        );
+        IL2ReverseRegistrar(l2ReverseRegistrar)
+            .setNameForAddrWithSignature(addr, signatureExpiry, name, cointypes, signature);
         return setNameForAddr(addr, msg.sender, defaultResolver, name);
     }
 
@@ -212,11 +211,7 @@ contract ReverseRegistrarV2 is Ownable {
     /// @param resolver The address of the resolver to set.
     ///
     /// @return The ENS node hash of the base-specific reverse record.
-    function claimForBaseAddr(address addr, address owner, address resolver)
-        public
-        authorized(addr)
-        returns (bytes32)
-    {
+    function claimForBaseAddr(address addr, address owner, address resolver) public authorized(addr) returns (bytes32) {
         bytes32 labelHash = Sha3.hexAddress(addr);
         bytes32 baseReverseNode = keccak256(abi.encodePacked(reverseNode, labelHash));
         emit BaseReverseClaimed(addr, baseReverseNode);

--- a/src/L2/UpgradeableL2Resolver.sol
+++ b/src/L2/UpgradeableL2Resolver.sol
@@ -5,8 +5,9 @@ import {ENS} from "ens-contracts/registry/ENS.sol";
 import {ExtendedResolver} from "ens-contracts/resolvers/profiles/ExtendedResolver.sol";
 import {IExtendedResolver} from "ens-contracts/resolvers/profiles/IExtendedResolver.sol";
 import {Multicallable} from "ens-contracts/resolvers/Multicallable.sol";
-import {Ownable2StepUpgradeable} from
-    "lib/openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {
+    Ownable2StepUpgradeable
+} from "lib/openzeppelin-contracts-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
 
 import {ABIResolver} from "./resolver/ABIResolver.sol";
 import {AddrResolver} from "./resolver/AddrResolver.sol";

--- a/src/L2/UpgradeableRegistrarController.sol
+++ b/src/L2/UpgradeableRegistrarController.sol
@@ -468,11 +468,8 @@ contract UpgradeableRegistrarController is Ownable2StepUpgradeable {
     ///
     /// @return price The `Price` tuple containing the base and premium prices respectively, denominated in wei.
     function rentPrice(string memory name, uint256 duration) public view returns (IPriceOracle.Price memory price) {
-        price = _getURCStorage().prices.price({
-            name: name,
-            expires: _getExpiry(uint256(_getLabelFromName(name))),
-            duration: duration
-        });
+        price = _getURCStorage().prices
+            .price({name: name, expires: _getExpiry(uint256(_getLabelFromName(name))), duration: duration});
     }
 
     /// @notice Checks the register price for a provided `name` and `duration`.
@@ -614,13 +611,10 @@ contract UpgradeableRegistrarController is Ownable2StepUpgradeable {
     /// @param request The `RegisterRequest` struct containing the details for the registration.
     function _register(RegisterRequest calldata request) internal {
         bytes32 label = _getLabelFromName(request.name);
-        uint256 expires = _getURCStorage().base.registerWithRecord({
-            id: uint256(label),
-            owner: request.owner,
-            duration: request.duration,
-            resolver: request.resolver,
-            ttl: 0
-        });
+        uint256 expires = _getURCStorage().base
+            .registerWithRecord({
+                id: uint256(label), owner: request.owner, duration: request.duration, resolver: request.resolver, ttl: 0
+            });
 
         if (request.data.length > 0) {
             _setRecords(request.resolver, label, request.data);
@@ -678,9 +672,8 @@ contract UpgradeableRegistrarController is Ownable2StepUpgradeable {
         string memory fullName = string.concat(name, $.rootName);
         _setLegacyReverseRecord(fullName, msg.sender);
         if (signatureExpiry != 0 && coinTypes.length > 0 && signature.length > 0) {
-            IL2ReverseRegistrar($.l2ReverseRegistrar).setNameForAddrWithSignature(
-                msg.sender, signatureExpiry, fullName, coinTypes, signature
-            );
+            IL2ReverseRegistrar($.l2ReverseRegistrar)
+                .setNameForAddrWithSignature(msg.sender, signatureExpiry, fullName, coinTypes, signature);
         }
     }
 

--- a/src/L2/resolver/ABIResolver.sol
+++ b/src/L2/resolver/ABIResolver.sol
@@ -38,7 +38,7 @@ abstract contract ABIResolver is IABIResolver, ResolverBase {
         if (((contentType - 1) & contentType) != 0) revert InvalidContentType();
 
         _getABIResolverStorage().versionable_abis[_getResolverBaseStorage().recordVersions[node]][node][contentType] =
-            data;
+        data;
         emit ABIChanged(node, contentType);
     }
 

--- a/src/L2/resolver/AddrResolver.sol
+++ b/src/L2/resolver/AddrResolver.sol
@@ -62,8 +62,8 @@ abstract contract AddrResolver is IAddrResolver, IAddressResolver, ResolverBase 
         if (coinType == COIN_TYPE_ETH) {
             emit AddrChanged(node, address(bytes20(a)));
         }
-        _getAddrResolverStorage().versionable_addresses[_getResolverBaseStorage().recordVersions[node]][node][coinType]
-        = a;
+        _getAddrResolverStorage()
+        .versionable_addresses[_getResolverBaseStorage().recordVersions[node]][node][coinType] = a;
     }
 
     /// @notice Returns the address associated with a specified ENS `node`.

--- a/src/L2/resolver/DNSResolver.sol
+++ b/src/L2/resolver/DNSResolver.sol
@@ -101,7 +101,8 @@ abstract contract DNSResolver is IDNSRecordResolver, IDNSZoneResolver, ResolverB
         override
         returns (bytes memory)
     {
-        return _getDNSResolverStorage().versionable_records[_getResolverBaseStorage().recordVersions[node]][node][name][resource];
+        return _getDNSResolverStorage()
+        .versionable_records[_getResolverBaseStorage().recordVersions[node]][node][name][resource];
     }
 
     /// @notice Check if a given node has records.
@@ -111,10 +112,8 @@ abstract contract DNSResolver is IDNSRecordResolver, IDNSZoneResolver, ResolverB
     ///
     /// @return `True` if records are stored for this node + name, else `False`.
     function hasDNSRecords(bytes32 node, bytes32 name) external view virtual returns (bool) {
-        return (
-            _getDNSResolverStorage().versionable_nameEntriesCount[_getResolverBaseStorage().recordVersions[node]][node][name]
-                != 0
-        );
+        return (_getDNSResolverStorage()
+                .versionable_nameEntriesCount[_getResolverBaseStorage().recordVersions[node]][node][name] != 0);
     }
 
     /// @notice Sets the hash for the zone.

--- a/src/L2/resolver/InterfaceResolver.sol
+++ b/src/L2/resolver/InterfaceResolver.sol
@@ -33,8 +33,8 @@ abstract contract InterfaceResolver is IInterfaceResolver, ResolverBase {
     /// @param interfaceID The EIP-165 interface ID.
     /// @param implementer The address of a contract that implements this interface for this node.
     function setInterface(bytes32 node, bytes4 interfaceID, address implementer) external virtual authorized(node) {
-        _getInterfaceResolverStorage().versionable_interfaces[_getResolverBaseStorage().recordVersions[node]][node][interfaceID]
-        = implementer;
+        _getInterfaceResolverStorage()
+        .versionable_interfaces[_getResolverBaseStorage().recordVersions[node]][node][interfaceID] = implementer;
         emit InterfaceChanged(node, interfaceID, implementer);
     }
 
@@ -49,8 +49,8 @@ abstract contract InterfaceResolver is IInterfaceResolver, ResolverBase {
     ///
     /// @return The address that implements this interface, or address(0) if the interface is unsupported.
     function interfaceImplementer(bytes32 node, bytes4 interfaceID) external view virtual override returns (address) {
-        address implementer = _getInterfaceResolverStorage().versionable_interfaces[_getResolverBaseStorage()
-            .recordVersions[node]][node][interfaceID];
+        address implementer = _getInterfaceResolverStorage()
+        .versionable_interfaces[_getResolverBaseStorage().recordVersions[node]][node][interfaceID];
         if (implementer != address(0)) {
             return implementer;
         }

--- a/src/L2/resolver/ResolverBase.sol
+++ b/src/L2/resolver/ResolverBase.sol
@@ -19,7 +19,8 @@ abstract contract ResolverBase is ERC165, IVersionableResolver {
 
     /// @notice EIP-7201 storage location.
     // keccak256(abi.encode(uint256(keccak256("resolver.base.storage")) - 1)) & ~bytes32(uint256(0xff));
-    bytes32 private constant RESOLVER_BASE_LOCATION = 0x421bc1b234e222da5ef3c41832b689b450ae239e8b18cf3c05f5329ae7d99700;
+    bytes32 private constant RESOLVER_BASE_LOCATION =
+        0x421bc1b234e222da5ef3c41832b689b450ae239e8b18cf3c05f5329ae7d99700;
 
     /// @notice Decorator for record-write authorization checks.
     modifier authorized(bytes32 node) {

--- a/src/lib/EDAPrice.sol
+++ b/src/lib/EDAPrice.sol
@@ -5,19 +5,15 @@ import "solady/utils/FixedPointMathLib.sol";
 
 library EDAPrice {
     /// @notice returns the current price of an exponential price decay auction defined by the passed params
-
     /// @dev reverts if perPeriodDecayPercentWad >= 1e18
     /// @dev reverts if uint256 secondsInPeriod = 0
     /// @dev reverts if startPrice * multiplier overflows
     /// @dev reverts if lnWad(percentWadRemainingPerPeriod) * ratio) overflows
-
     /// @param startPrice the starting price of the auction
     /// @param secondsElapsed the seconds elapsed since auction start
     /// @param secondsInPeriod the seconds over which the price should decay perPeriodDecayPercentWad
     /// @param perPeriodDecayPercentWad the percent the price should decay during secondsInPeriod, 100% = 1e18
-
     /// @return price the current auction price
-
     function currentPrice(
         uint256 startPrice,
         uint256 secondsElapsed,

--- a/test/EARegistrarController/EARegistrarControllerBase.t.sol
+++ b/test/EARegistrarController/EARegistrarControllerBase.t.sol
@@ -75,19 +75,11 @@ contract EARegistrarControllerBase is Test {
 
     function _getDefaultDiscount() internal view returns (EARegistrarController.DiscountDetails memory) {
         return EARegistrarController.DiscountDetails({
-            active: true,
-            discountValidator: address(validator),
-            key: discountKey,
-            discount: discountAmount
+            active: true, discountValidator: address(validator), key: discountKey, discount: discountAmount
         });
     }
 
-    function _getDefaultRegisterRequest()
-        internal
-        view
-        virtual
-        returns (EARegistrarController.RegisterRequest memory)
-    {
+    function _getDefaultRegisterRequest() internal view virtual returns (EARegistrarController.RegisterRequest memory) {
         return EARegistrarController.RegisterRequest({
             name: name,
             owner: user,

--- a/test/Integration/SwitchToUpgradeableRegistrarController.t.sol
+++ b/test/Integration/SwitchToUpgradeableRegistrarController.t.sol
@@ -11,8 +11,9 @@ import {MockReverseRegistrarV2} from "test/mocks/MockReverseRegistrarV2.sol";
 import {ExponentialPremiumPriceOracle} from "src/L2/ExponentialPremiumPriceOracle.sol";
 import {IPriceOracle} from "src/L2/interface/IPriceOracle.sol";
 import {UpgradeableRegistrarController} from "src/L2/UpgradeableRegistrarController.sol";
-import {TransparentUpgradeableProxy} from
-    "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {
+    TransparentUpgradeableProxy
+} from "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {BASE_ETH_NODE, GRACE_PERIOD} from "src/util/Constants.sol";
 

--- a/test/RegistrarController/RegistrarControllerBase.t.sol
+++ b/test/RegistrarController/RegistrarControllerBase.t.sol
@@ -82,10 +82,7 @@ contract RegistrarControllerBase is Test {
 
     function _getDefaultDiscount() internal view returns (RegistrarController.DiscountDetails memory) {
         return RegistrarController.DiscountDetails({
-            active: true,
-            discountValidator: address(validator),
-            key: discountKey,
-            discount: discountAmount
+            active: true, discountValidator: address(validator), key: discountKey, discount: discountAmount
         });
     }
 

--- a/test/UpgradeableL2Resolver/UpgradeableL2ResolverBase.t.sol
+++ b/test/UpgradeableL2Resolver/UpgradeableL2ResolverBase.t.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
 import {UpgradeableL2Resolver} from "src/L2/UpgradeableL2Resolver.sol";
-import {TransparentUpgradeableProxy} from
-    "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {
+    TransparentUpgradeableProxy
+} from "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {Registry} from "src/L2/Registry.sol";
 import {ENS} from "ens-contracts/registry/ENS.sol";
 import {ETH_NODE, BASE_ETH_NODE, REVERSE_NODE} from "src/util/Constants.sol";

--- a/test/UpgradeableRegistrarController/UpgradeableRegistrarControllerBase.t.sol
+++ b/test/UpgradeableRegistrarController/UpgradeableRegistrarControllerBase.t.sol
@@ -6,8 +6,9 @@ import {BaseRegistrar} from "src/L2/BaseRegistrar.sol";
 import {ENS} from "ens-contracts/registry/ENS.sol";
 import {IPriceOracle} from "src/L2/interface/IPriceOracle.sol";
 import {IReverseRegistrar} from "src/L2/interface/IReverseRegistrar.sol";
-import {TransparentUpgradeableProxy} from
-    "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {
+    TransparentUpgradeableProxy
+} from "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {Registry} from "src/L2/Registry.sol";
 import {UpgradeableRegistrarController} from "src/L2/UpgradeableRegistrarController.sol";
 
@@ -93,10 +94,7 @@ contract UpgradeableRegistrarControllerBase is Test {
 
     function _getDefaultDiscount() internal view returns (UpgradeableRegistrarController.DiscountDetails memory) {
         return UpgradeableRegistrarController.DiscountDetails({
-            active: true,
-            discountValidator: address(validator),
-            key: discountKey,
-            discount: discountAmount
+            active: true, discountValidator: address(validator), key: discountKey, discount: discountAmount
         });
     }
 


### PR DESCRIPTION
## Summary
Applied consistent code formatting using `forge fmt` to ensure all Solidity files conform to the project's formatting standards.

## Changes
Formatted 15 files:
- `src/L2/ReverseRegistrar.sol`
- `src/L2/ReverseRegistrarV2.sol`
- `src/L2/UpgradeableL2Resolver.sol`
- `src/L2/UpgradeableRegistrarController.sol`
- `src/L2/resolver/ABIResolver.sol`
- `src/L2/resolver/AddrResolver.sol`
- `src/L2/resolver/DNSResolver.sol`
- `src/L2/resolver/InterfaceResolver.sol`
- `src/L2/resolver/ResolverBase.sol`
- `src/lib/EDAPrice.sol`
- `test/EARegistrarController/EARegistrarControllerBase.t.sol`
- `test/Integration/SwitchToUpgradeableRegistrarController.t.sol`
- `test/RegistrarController/RegistrarControllerBase.t.sol`
- `test/UpgradeableL2Resolver/UpgradeableL2ResolverBase.t.sol`
- `test/UpgradeableRegistrarController/UpgradeableRegistrarControllerBase.t.sol`

## Why
Consistent formatting improves code readability and ensures CI checks pass when `forge fmt --check` is run.